### PR TITLE
Fix enabling/disabling of collectors

### DIFF
--- a/jobs/node_exporter/spec
+++ b/jobs/node_exporter/spec
@@ -59,90 +59,133 @@ properties:
 
   node_exporter.collector.arp.enabled:
     description: "Enable the arp collector (default: enabled)"
+    default: true
   node_exporter.collector.bcache.enabled:
     description: "Enable the bcache collector (default: enabled)"
+    default: true
   node_exporter.collector.bonding.enabled:
     description: "Enable the bonding collector (default: disabled)"
+    default: true
   node_exporter.collector.buddyinfo.enabled:
     description: "Enable the buddyinfo collector (default: disabled)"
+    default: false
   node_exporter.collector.conntrack.enabled:
     description: "Enable the conntrack collector (default: enabled)"
+    default: true
   node_exporter.collector.cpu.enabled:
     description: "Enable the cpu collector (default: enabled)"
+    default: true
   node_exporter.collector.diskstats.enabled:
     description: "Enable the diskstats collector (default: enabled)"
+    default: true
   node_exporter.collector.drbd.enabled:
     description: "Enable the drbd collector (default: disabled)"
+    default: false
   node_exporter.collector.edac.enabled:
     description: "Enable the edac collector (default: enabled)"
+    default: true
   node_exporter.collector.entropy.enabled:
     description: "Enable the entropy collector (default: enabled)"
+    default: true
   node_exporter.collector.filefd.enabled:
     description: "Enable the filefd collector (default: enabled)"
+    default: true
   node_exporter.collector.filesystem.enabled:
     description: "Enable the filesystem collector (default: enabled)"
+    default: true
   node_exporter.collector.hwmon.enabled:
     description: "Enable the hwmon collector (default: enabled)"
+    default: true
   node_exporter.collector.infiniband.enabled:
     description: "Enable the infiniband collector (default: enabled)"
+    default: true
   node_exporter.collector.interrupts.enabled:
     description: "Enable the interrupts collector (default: disabled)"
-  node_exporter.collector.ipvsd.enabled:
+    default: false
+  node_exporter.collector.ipvs.enabled:
     description: "Enable the ipvs collector (default: enabled)"
+    default: true
   node_exporter.collector.ksmd.enabled:
     description: "Enable the ksmd collector (default: disabled)"
+    default: false
   node_exporter.collector.loadavg.enabled:
     description: "Enable the loadavg collector (default: enabled)"
+    default: true
   node_exporter.collector.logind.enabled:
     description: "Enable the logind collector (default: disabled)"
+    default: false
   node_exporter.collector.mdadm.enabled:
     description: "Enable the mdadm collector (default: enabled)"
+    default: true
   node_exporter.collector.meminfo.enabled:
     description: "Enable the meminfo collector (default: enabled)"
+    default: true
   node_exporter.collector.meminfo_numa.enabled:
     description: "Enable the meminfo_numa collector (default: disabled)"
+    default: false
   node_exporter.collector.mountstats.enabled:
     description: "Enable the mountstats collector (default: disabled)"
+    default: false
   node_exporter.collector.netdev.enabled:
     description: "Enable the netdev collector (default: enabled)"
+    default: true
   node_exporter.collector.netstat.enabled:
     description: "Enable the netstat collector (default: enabled)"
+    default: true
   node_exporter.collector.nfs.enabled:
     description: "Enable the nfs collector (default: disabled)"
+    default: false
   node_exporter.collector.nfsd.enabled:
     description: "Enable the nfsd collector (default: enabled)"
+    default: true
   node_exporter.collector.ntp.enabled:
     description: "Enable the ntp collector (default: disabled)"
+    default: false
   node_exporter.collector.qdisc.enabled:
     description: "Enable the qdisc collector (default: disabled)"
+    default: false
   node_exporter.collector.runit.enabled:
     description: "Enable the runit collector (default: disabled)"
+    default: false
   node_exporter.collector.sockstat.enabled:
     description: "Enable the sockstat collector (default: enabled)"
+    default: true
   node_exporter.collector.stat.enabled:
     description: "Enable the stat collector (default: enabled)"
+    default: true
   node_exporter.collector.supervisord.enabled:
     description: "Enable the supervisord collector (default: disabled)"
+    default: false
   node_exporter.collector.systemd.enabled:
     description: "Enable the systemd collector (default: disabled)"
+    default: false
   node_exporter.collector.tcpstat.enabled:
     description: "Enable the tcpstat collector (default: disabled)"
+    default: false
   node_exporter.collector.textfile.enabled:
     description: "Enable the textfile collector (default: enabled)"
+    default: true
   node_exporter.collector.time.enabled:
     description: "Enable the time collector (default: enabled)"
+    default: true
   node_exporter.collector.uname.enabled:
     description: "Enable the uname collector (default: enabled)"
+    default: true
   node_exporter.collector.vmstat.enabled:
     description: "Enable the vmstat collector (default: enabled)"
+    default: true
   node_exporter.collector.wifi.enabled:
     description: "Enable the wifi collector (default: enabled)"
+    default: true
   node_exporter.collector.xfs.enabled:
     description: "Enable the xfs collector (default: enabled)"
+    default: true
   node_exporter.collector.zfs.enabled:
     description: "Enable the zfs collector (default: enabled)"
+    default: true
   node_exporter.collector.timex.enabled:
     description: "Enable the timex collector (default: enabled)"
+    default: true
 
   node_exporter.web.port:
     description: "Port on which to expose metrics and web interface"

--- a/jobs/node_exporter/templates/bin/node_exporter_ctl
+++ b/jobs/node_exporter/templates/bin/node_exporter_ctl
@@ -16,6 +16,54 @@ exec 2>> ${LOG_DIR}/$(basename "$0").stderr.log
 
 export PATH=/var/vcap/packages/node_exporter/bin:${PATH}
 
+<%
+    collectors = %w|
+      arp
+      bcache
+      bonding
+      buddyinfo
+      conntrack
+      cpu
+      diskstats
+      drbd
+      edac
+      entropy
+      filefd
+      filesystem
+      hwmon
+      infiniband
+      interrupts
+      ipvs
+      ksmd
+      loadavg
+      logind
+      mdadm
+      meminfo
+      meminfo_numa
+      mountstats
+      netdev
+      netstat
+      nfs
+      nfsd
+      ntp
+      qdisc
+      runit
+      sockstat
+      stat
+      supervisord
+      systemd
+      tcpstat
+      textfile
+      time
+      timex
+      uname
+      vmstat
+      wifi
+      xfs
+      zfs
+    |
+%>
+
 case $1 in
   start)
     pid_guard ${PIDFILE} "node_exporter"
@@ -81,134 +129,10 @@ case $1 in
       <% if_p('node_exporter.collector.vmstat.fields') do |fields| %> \
       --collector.vmstat.fields="<%= fields %>" \
       <% end %> \
-      <% if_p('node_exporter.collector.arp.enabled') do |enabled| %> \
-      --collector.arp="<%= enabled %>" \
+      <% collectors.each do |collector| %> \
+      <% if_p("node_exporter.collector.#{collector}.enabled") do |enabled| %> \
+       <%= enabled ? "--collector.#{collector}" : "--no-collector.#{collector}" %> \
       <% end %> \
-      <% if_p('node_exporter.collector.bcache.enabled') do |enabled| %> \
-      --collector.bcache="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.bonding.enabled') do |enabled| %> \
-      --collector.bonding="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.buddyinfo.enabled') do |enabled| %> \
-      --collector.buddyinfo="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.conntrack.enabled') do |enabled| %> \
-      --collector.conntrack="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.cpu.enabled') do |enabled| %> \
-      --collector.cpu="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.diskstats.enabled') do |enabled| %> \
-      --collector.diskstats="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.drbd.enabled') do |enabled| %> \
-      --collector.drbd="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.edac.enabled') do |enabled| %> \
-      --collector.edac="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.entropy.enabled') do |enabled| %> \
-      --collector.entropy="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.filefd.enabled') do |enabled| %> \
-      --collector.filefd="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.filesystem.enabled') do |enabled| %> \
-      --collector.filesystem="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.hwmon.enabled') do |enabled| %> \
-      --collector.hwmon="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.infiniband.enabled') do |enabled| %> \
-      --collector.infiniband="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.interrupts.enabled') do |enabled| %> \
-      --collector.interrupts="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.ipvsd.enabled') do |enabled| %> \
-      --collector.ipvs="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.ksmd.enabled') do |enabled| %> \
-      --collector.ksmd="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.loadavg.enabled') do |enabled| %> \
-      --collector.loadavg="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.logind.enabled') do |enabled| %> \
-      --collector.logind="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.mdadm.enabled') do |enabled| %> \
-      --collector.mdadm="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.meminfo.enabled') do |enabled| %> \
-      --collector.meminfo="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.meminfo_numa.enabled') do |enabled| %> \
-      --collector.meminfo_numa="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.mountstats.enabled') do |enabled| %> \
-      --collector.mountstats="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.netdev.enabled') do |enabled| %> \
-      --collector.netdev="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.netstat.enabled') do |enabled| %> \
-      --collector.netstat="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.nfs.enabled') do |enabled| %> \
-      --collector.nfs="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.nfsd.enabled') do |enabled| %> \
-      --collector.nfsd="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.ntp.enabled') do |enabled| %> \
-      --collector.ntp="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.qdisc.enabled') do |enabled| %> \
-       --collector.qdisc="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.runit.enabled') do |enabled| %> \
-      --collector.runit="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.sockstat.enabled') do |enabled| %> \
-      --collector.sockstat="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.stat.enabled') do |enabled| %> \
-      --collector.stat="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.supervisord.enabled') do |enabled| %> \
-      --collector.supervisord="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.systemd.enabled') do |enabled| %> \
-      --collector.systemd="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.tcpstat.enabled') do |enabled| %> \
-      --collector.tcpstat="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.textfile.enabled') do |enabled| %> \
-      --collector.textfile="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.time.enabled') do |enabled| %> \
-      --collector.time="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.uname.enabled') do |enabled| %> \
-      --collector.uname="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.vmstat.enabled') do |enabled| %> \
-      --collector.vmstat="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.wifi.enabled') do |enabled| %> \
-      --collector.wifi="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.xfs.enabled') do |enabled| %> \
-      --collector.xfs="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.zfs.enabled') do |enabled| %> \
-      --collector.zfs="<%= enabled %>" \
-      <% end %> \
-      <% if_p('node_exporter.collector.timex.enabled') do |enabled| %> \
-      --collector.timex="<%= enabled %>" \
       <% end %> \
       --web.listen-address=":<%= p('node_exporter.web.port') %>" \
       <% if_p('node_exporter.web.telemetry_path') do |telemetry_path| %> \


### PR DESCRIPTION
The node_exporter uses the '--collector.<name>' to enable collectors and '--no-collector.<name>' to disable collectors. This changes the node_exporter template generation to specify '--collector.<name>' or '--no-collector.<name>' for all available collectors and explicitly sets the defaults in the spec.

Also, fixed ipvsd collector name to ipvs.