### PR TITLE
Add support for netdev.address-info

### DIFF
--- a/jobs/node_exporter/spec
+++ b/jobs/node_exporter/spec
@@ -36,6 +36,9 @@ properties:
     description: "Regexp of net devices to blacklist"
   node_exporter.collector.netdev.device_whitelist:
     description: "Regexp of net devices to whitelist"
+  node_exporter.collector.netdev.address_info:
+    description: "Collect address-info for every device (default false)"
+    default: false
 
   node_exporter.collector.netstat.fields:
     description: "Regexp of fields to return for netstat collector"

--- a/jobs/node_exporter/templates/bin/node_exporter_ctl.erb
+++ b/jobs/node_exporter/templates/bin/node_exporter_ctl.erb
@@ -110,6 +110,9 @@ case $1 in
       <% if_p('node_exporter.collector.netclass.ignored_devices') do |ignored_devices| %> \
       --collector.netclass.ignored-devices="<%= ignored_devices %>" \
       <% end %> \
+      <% if_p('node_exporter.collector.netdev.address_info') do |address_info| %> \
+      --collector.netdev.address-info="<%= address_info %>" \
+      <% end %> \
       <% if_p('node_exporter.collector.netdev.device_blacklist') do |device_blacklist| %> \
       --collector.netdev.device-blacklist="<%= device_blacklist %>" \
       <% end %> \


### PR DESCRIPTION
Would emit (interface, addr, netmask, scope) labels for every network interface

See https://github.com/prometheus/node_exporter/pull/2105

This complements current bosh exporter support for a single IP address, see https://github.com/bosh-prometheus/bosh_exporter/pull/18