### PR TITLE
Fix missing trailing slash in bin file.

### DIFF
--- a/jobs/node_exporter/templates/bin/node_exporter_ctl.erb
+++ b/jobs/node_exporter/templates/bin/node_exporter_ctl.erb
@@ -111,9 +111,9 @@ case $1 in
       --collector.netclass.ignored-devices="<%= ignored_devices %>" \
       <% end %> \
       <% if_p('node_exporter.collector.netdev.address_info') do |address_info| %> \
-      <% if address_info %>
+      <% if address_info %> \
       --collector.netdev.address-info \
-      <% end %>
+      <% end %> \
       <% end %> \
       <% if_p('node_exporter.collector.netdev.device_blacklist') do |device_blacklist| %> \
       --collector.netdev.device-blacklist="<%= device_blacklist %>" \


### PR DESCRIPTION
Without the trailing slashes the bin file is generated with a blank line which is causing all the parameters after that point to be ignored.