### PR TITLE
[ci] Introduce basic CI executing Unit-Tests

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,14 @@
+FROM bosh/docker-cpi:main
+
+# Install all necessary tools for haproxy testflight and dependency autobump
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y wget jq git vim nano && \
+    apt-get clean
+
+# Set bosh env at login
+RUN echo "source /tmp/local-bosh/director/env" >> /root/.bashrc
+
+# Install go dependencies
+ENV GOBIN=/usr/local/bin
+RUN go install github.com/geofffranks/spruce/cmd/spruce@latest

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,113 @@
+---
+
+groups:
+  - name: node-exporter-boshrelease
+    jobs:
+      - unit-tests
+      - unit-tests-pr
+
+jobs:
+  - name: unit-tests
+    public: true
+    serial: true
+    plan:
+    - do:
+      - get: git
+        trigger: true
+      - task: unit-tests
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: bguttmannavtq/pipeline-image
+              tag:        latest
+          inputs:
+            - { name: git }
+          caches:
+          - path: git/vendor/cache
+          - path: git/.bundle
+          run:
+            path: ./git/ci/scripts/unit-tests
+            args: []
+          params:
+            REPO_ROOT: git
+      on_failure:
+        put: notify
+        params:
+          channel:  "#prometheus"
+          username: ci-bot
+  - name: unit-tests-pr
+    public: true
+    serial: true
+    plan:
+    - do:
+      - { get: git-pull-requests, trigger: true, version: every }
+      - put: git-pull-requests
+        params:
+          path: git-pull-requests
+          status: pending
+          context: unit-tests
+      - task: unit-tests
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: bguttmannavtq/pipeline-image
+              tag:        latest
+          inputs:
+            - { name: git-pull-requests }
+          caches:
+          - path: git-pull-requests/vendor/cache
+          - path: git-pull-requests/.bundle
+          run:
+            path: ./git-pull-requests/ci/scripts/unit-tests
+            args: []
+          params:
+            REPO_ROOT: git-pull-requests
+    on_success:
+      put: git-pull-requests
+      params:
+        path: git-pull-requests
+        status: success
+        context: unit-tests
+    on_failure:
+      put: git-pull-requests
+      params:
+        path: git-pull-requests
+        status: failure
+        context: unit-tests
+
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: cfcommunity/github-pr-resource
+
+resources:
+  - name: notify
+    type: slack-notification
+    source:
+      url: ((slack.url))
+
+  - name: git
+    type: git
+    source:
+      uri:         git@github.com:cloudfoundry/node-exporter-boshrelease.git
+      branch:      master
+      private_key: ((github.private_key))
+      private_key_user: ((github.bot_user))
+
+  - name: git-pull-requests
+    type: pull-request
+    source:
+      access_token: ((github.token))
+      repository:   cloudfoundry/node-exporter-boshrelease
+      base_branch:  master
+      labels:       [run-ci]

--- a/ci/scripts/unit-tests
+++ b/ci/scripts/unit-tests
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd ${REPO_ROOT}/spec
+
+bundle install
+bundle exec rspec . --format documentation


### PR DESCRIPTION
Introducing a basic pipeline (inspired by Haproxy Boshrelease). The pipeline runs the unit tests for every merged commit to master as well as for PRs if the `run-ci` label is added to the PR 